### PR TITLE
Change tool window name

### DIFF
--- a/src/main/kotlin/com/github/baristageek/watermelonintellij/actions/GitBlameAction.kt
+++ b/src/main/kotlin/com/github/baristageek/watermelonintellij/actions/GitBlameAction.kt
@@ -15,7 +15,7 @@ class GitBlameAction : AnAction() {
         // open tool window programmatically
         val project = ProjectManager.getInstance().getOpenProjects()[0]
         val toolWindowManager = ToolWindowManager.getInstance(project)
-        val toolWindow: ToolWindow? = toolWindowManager.getToolWindow("MyToolWindow")
+        val toolWindow: ToolWindow? = toolWindowManager.getToolWindow("🍉 Watermelon")
 
 //         val service = toolWindow.project.service<MyProjectService>()
         val service = toolWindow?.project?.service<MyProjectService>()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
     <resource-bundle>messages.MyBundle</resource-bundle>
 
     <extensions defaultExtensionNs="com.intellij">
-        <toolWindow factoryClass="com.github.baristageek.watermelonintellij.toolWindow.MyToolWindowFactory" id="MyToolWindow"/>
+        <toolWindow factoryClass="com.github.baristageek.watermelonintellij.toolWindow.MyToolWindowFactory" id="🍉 Watermelon"/>
     </extensions>
 
 <!--    <extensions defaultExtensionNs="com.intellij.openapi.editor">-->


### PR DESCRIPTION
## Description
Changes tool window name (the tab on the plugin sidebar) from MyToolWindow to Watermelon 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
