### PR TITLE
Add mandatory plugin description section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/WatermelonTools?style=flat-square)](https://twitter.com/intent/follow?screen_name=WatermelonTools)
 [![Discord](https://img.shields.io/discord/933846506438541492?style=flat-square)](https://discord.com/invite/H4AE6b9442)
 
+<!-- Plugin description -->
 **Watermelon is a Passive Documentation Search Engine** serving both our GitHub app and IDE extensions. Our set of plug-ins help developers understand code context, improve their coding velocity and merge PRs like a breeze.
 
 We've built a search algorithm that indexes the most relevant [passive documentation](https://www.watermelontools.com/post/what-is-passive-code-documentation-why-is-it-hard-to-scale-what-to-do-about-it) for a given block of code.
@@ -17,7 +18,7 @@ We've built a search algorithm that indexes the most relevant [passive documenta
 To obtain business context in your IDE, use this extension.
 
 To obtain business context in your CI/CD, take a look at our [GitHub Application](https://github.com/watermelontools/watermelon)
-
+<!-- Plugin description end -->
 
 ## Integrations
 


### PR DESCRIPTION
## Description
Plugins need to have a mandatory plugin description section in the README. Else, they won't build. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [x] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
