### PR TITLE
Bugfix: Git Blame by Range - Try the approach with GitHandler

### DIFF
--- a/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
+++ b/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
@@ -9,6 +9,10 @@ import com.intellij.vcsUtil.VcsUtil
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
+import git4idea.commands.GitCommand
+import git4idea.commands.GitLineHandler
+import git4idea.commands.Git;
+
 
 @Service(Service.Level.PROJECT)
 class MyProjectService(project: Project) {
@@ -35,19 +39,25 @@ class MyProjectService(project: Project) {
 
         val history = git4idea.history.GitFileHistory;
 
-        val blameResult = history.collectHistory(project, filePath)
-        val commitHashes = ArrayList<String>()
-        val commitMessages = ArrayList<String>()
-        blameResult.forEach {
-            val commitMessageWithAuthor = "${it.author}: ${it.commitMessage}"
-            val stringElement = it.toString().split(":")[1]
-            commitHashes.add(stringElement)
-            commitMessages.add(commitMessageWithAuthor)
-        }
+        //     old approach   val blameResult = history.collectHistory(project, filePath)
+        val h = GitLineHandler(project, filePath.virtualFile!!, GitCommand.BLAME)
+        h.setSilent(true)
+        h.addParameters("-L ${startLine},${endLine}")
+        val blameResult = Git.getInstance().runCommand(h).output;
+        println("l53 blameResult: $blameResult")
+        // fix blame range above
 
-        // TODO: Run a blame range correctly
-        // val rangeBlame = blameResult.slice(start..end);
-        // println("rangeblame: $rangeBlame");
+
+        val commitHashes = ArrayList<String>()
+//        val commitMessages = ArrayList<String>()
+        val commitMessages = arrayListOf("jskfljsf")
+
+//        blameResult.forEach {
+//            val commitMessageWithAuthor = "${it.author}: ${it.commitMessage}"
+//            val stringElement = it.toString().split(":")[1]
+//            commitHashes.add(stringElement)
+//            commitMessages.add(commitMessageWithAuthor)
+//        }
 
         return (commitMessages);
     }

--- a/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
+++ b/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
@@ -38,12 +38,10 @@ class MyProjectService(project: Project) {
         val startLine = editor.document.getLineNumber(selectionModel.selectionStart)
         val endLine = editor.document.getLineNumber(selectionModel.selectionEnd)
 
-        val history = git4idea.history.GitFileHistory;
         val commitHashes = ArrayList<String>()
-
+//        val history = git4idea.history.GitFileHistory;
         //     old approach   val blameResult = history.collectHistory(project, filePath)
         val repository = GitRepositoryManager.getInstance(project).repositories[0]
-        println("repo root: ${repository.root}")
         val h = GitLineHandler(project, repository.root, GitCommand.BLAME)
         h.addParameters( "-L", "$startLine,$endLine")
         h.endOptions()
@@ -51,8 +49,6 @@ class MyProjectService(project: Project) {
 
         val result = Git.getInstance().runCommand(h)
         val output = result.getOutputOrThrow()
-//        println(output)
-        // fix blame range above
 
         output.split("\n").forEach { line ->
             val parts = line.split(" ")
@@ -60,8 +56,6 @@ class MyProjectService(project: Project) {
                 commitHashes.add(parts[0])
             }
         }
-
-        println(commitHashes)
 
         val commitDetails = ArrayList<String>()
 
@@ -74,28 +68,13 @@ class MyProjectService(project: Project) {
 
             // Extract author and commit message
             val logOutput = logResult.output.toString()
-//            val author = logOutput.split("\n")[0].split(" ")[1]
-//            val message = logOutput.split("\n")[4]
+            val author = logOutput.split("\n")[0].split(",")[1]
+            val message = logOutput.split("\n")[4]
 
-            println("logoutput $logOutput")
-            // Add to array
-//            commitDetails.add("$author: $message")
+            commitDetails.add("$author: $message")
         }
 
-        println("commitDetails: $commitDetails")
-
-
-//        val commitMessages = ArrayList<String>()
-        val commitMessages = arrayListOf("jskfljsf")
-
-//        blameResult.forEach {
-//            val commitMessageWithAuthor = "${it.author}: ${it.commitMessage}"
-//            val stringElement = it.toString().split(":")[1]
-//            commitHashes.add(stringElement)
-//            commitMessages.add(commitMessageWithAuthor)
-//        }
-
-        return (commitMessages);
+        return (commitDetails);
     }
 
 }

--- a/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
+++ b/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import git4idea.commands.GitCommand
 import git4idea.commands.GitLineHandler
 import git4idea.commands.Git;
+import git4idea.repo.GitRepositoryManager
 
 
 @Service(Service.Level.PROJECT)
@@ -40,11 +41,16 @@ class MyProjectService(project: Project) {
         val history = git4idea.history.GitFileHistory;
 
         //     old approach   val blameResult = history.collectHistory(project, filePath)
-        val h = GitLineHandler(project, filePath.virtualFile!!, GitCommand.BLAME)
-        h.setSilent(true)
-        h.addParameters("-L ${startLine},${endLine}")
-        val blameResult = Git.getInstance().runCommand(h).output;
-        println("l53 blameResult: $blameResult")
+        val repository = GitRepositoryManager.getInstance(project).repositories[0]
+        println("repo root: ${repository.root}")
+        val h = GitLineHandler(project, repository.root, GitCommand.BLAME)
+        h.addParameters("-p", "-L", "$startLine,$endLine")
+        h.endOptions()
+        h.addRelativeFiles(listOf(filePath.virtualFile))
+
+        val result = Git.getInstance().runCommand(h)
+        val output = result.getOutputOrThrow()
+        println(output)
         // fix blame range above
 
 

--- a/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
+++ b/src/main/kotlin/com/github/baristageek/watermelonintellij/services/MyProjectService.kt
@@ -39,22 +39,52 @@ class MyProjectService(project: Project) {
         val endLine = editor.document.getLineNumber(selectionModel.selectionEnd)
 
         val history = git4idea.history.GitFileHistory;
+        val commitHashes = ArrayList<String>()
 
         //     old approach   val blameResult = history.collectHistory(project, filePath)
         val repository = GitRepositoryManager.getInstance(project).repositories[0]
         println("repo root: ${repository.root}")
         val h = GitLineHandler(project, repository.root, GitCommand.BLAME)
-        h.addParameters("-p", "-L", "$startLine,$endLine")
+        h.addParameters( "-L", "$startLine,$endLine")
         h.endOptions()
         h.addRelativeFiles(listOf(filePath.virtualFile))
 
         val result = Git.getInstance().runCommand(h)
         val output = result.getOutputOrThrow()
-        println(output)
+//        println(output)
         // fix blame range above
 
+        output.split("\n").forEach { line ->
+            val parts = line.split(" ")
+            if (parts.size > 0) {
+                commitHashes.add(parts[0])
+            }
+        }
 
-        val commitHashes = ArrayList<String>()
+        println(commitHashes)
+
+        val commitDetails = ArrayList<String>()
+
+        for (hash in commitHashes) {
+
+            // Call git log for each hash
+            val log = GitLineHandler(project, repository.root, GitCommand.LOG)
+            log.addParameters(hash)
+            val logResult = Git.getInstance().runCommand(log)
+
+            // Extract author and commit message
+            val logOutput = logResult.output.toString()
+//            val author = logOutput.split("\n")[0].split(" ")[1]
+//            val message = logOutput.split("\n")[4]
+
+            println("logoutput $logOutput")
+            // Add to array
+//            commitDetails.add("$author: $message")
+        }
+
+        println("commitDetails: $commitDetails")
+
+
 //        val commitMessages = ArrayList<String>()
         val commitMessages = arrayListOf("jskfljsf")
 


### PR DESCRIPTION
## Description
This is an attempt to run git blame for a range of lines, similar to how our VS Code extension does. It's a draft PR because it doesn't work yet, despite [trying various approaches](https://github.com/watermelontools/watermelon-intellij/issues/23)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
Look at the issue I opened describing the [various approaches I tried ](https://github.com/watermelontools/watermelon-intellij/issues/23)to get more context. 

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
