### PR TITLE
Feature/telemetry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,10 @@ repositories {
     //maven { url = uri(urlEncode("https://jitpack.io")) }
 }
 
+dependencies {
+    implementation("com.posthog.java:posthog:1.1.0")
+}
+
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
     jvmToolchain(17)

--- a/src/main/kotlin/com/watermelon/context/actions/ContextMenuButton.kt
+++ b/src/main/kotlin/com/watermelon/context/actions/ContextMenuButton.kt
@@ -6,6 +6,9 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.watermelon.context.toolWindow.MyToolWindowFactory
+import com.watermelon.context.utils.PostHog
+//import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.application.PermanentInstallationID
 
 class ContextMenuButton : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -26,6 +29,10 @@ class ContextMenuButton : AnAction() {
                     toolWindowFactory.createToolWindowContent(project, toolWindow!!, startLine, endLine)
                 }
             }
+
+            val uuid = PermanentInstallationID.get();
+            PostHog.posthog.capture(uuid,
+                "intelliJ:GetCodeContext");
 
             toolWindow?.show {}
         }

--- a/src/main/kotlin/com/watermelon/context/actions/ContextMenuButton.kt
+++ b/src/main/kotlin/com/watermelon/context/actions/ContextMenuButton.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.watermelon.context.toolWindow.MyToolWindowFactory
 import com.watermelon.context.utils.PostHog
-//import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.PermanentInstallationID
 
 class ContextMenuButton : AnAction() {

--- a/src/main/kotlin/com/watermelon/context/actions/LoginAction.kt
+++ b/src/main/kotlin/com/watermelon/context/actions/LoginAction.kt
@@ -5,7 +5,9 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.ide.passwordSafe.PasswordSafe
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.PermanentInstallationID
 import com.intellij.openapi.ui.Messages
+import com.watermelon.context.utils.PostHog
 import kotlinx.serialization.json.*
 import java.net.HttpURLConnection
 import java.net.URL
@@ -54,6 +56,11 @@ class LoginAction : AnAction() {
     }
 
     override fun actionPerformed(e: AnActionEvent) {
+        // Capture telemetry event
+        val uuid = PermanentInstallationID.get();
+        PostHog.posthog.capture(uuid,
+            "intelliJ:login");
+
         // Open webpage
         BrowserUtil.browse("$backendUrl/intellij")
 

--- a/src/main/kotlin/com/watermelon/context/listeners/MyApplicationActivationListener.kt
+++ b/src/main/kotlin/com/watermelon/context/listeners/MyApplicationActivationListener.kt
@@ -6,5 +6,6 @@ import com.intellij.openapi.wm.IdeFrame
 internal class MyApplicationActivationListener : ApplicationActivationListener {
 
     override fun applicationActivated(ideFrame: IdeFrame) {
+
     }
 }

--- a/src/main/kotlin/com/watermelon/context/listeners/MyApplicationActivationListener.kt
+++ b/src/main/kotlin/com/watermelon/context/listeners/MyApplicationActivationListener.kt
@@ -1,11 +1,15 @@
 package com.watermelon.context.listeners
 
 import com.intellij.openapi.application.ApplicationActivationListener
+import com.intellij.openapi.application.PermanentInstallationID
 import com.intellij.openapi.wm.IdeFrame
+import com.watermelon.context.utils.PostHog
 
 internal class MyApplicationActivationListener : ApplicationActivationListener {
 
     override fun applicationActivated(ideFrame: IdeFrame) {
-
+        val uuid = PermanentInstallationID.get();
+        PostHog.posthog.capture(uuid,
+            "intelliJ:appActivated");
     }
 }

--- a/src/main/kotlin/com/watermelon/context/utils/PostHog.kt
+++ b/src/main/kotlin/com/watermelon/context/utils/PostHog.kt
@@ -2,9 +2,9 @@ package com.watermelon.context.utils
 import com.posthog.java.PostHog
 object PostHog {
 
-    // still need to figure this out
-//    private val POSTHOG_API_KEY = System.getProperties().get("POSTHOG_API_KEY") as String;
-//    private val POSTHOG_HOST = System.getProperties().get("POSTHOG_HOST") as String;
+    // manually insert API key here
+    private val POSTHOG_API_KEY = "POSTHOG_API_KEY";
+    private val POSTHOG_HOST = "POSTHOG_HOST";
 
 
     val posthog = PostHog.Builder(POSTHOG_API_KEY)

--- a/src/main/kotlin/com/watermelon/context/utils/PostHog.kt
+++ b/src/main/kotlin/com/watermelon/context/utils/PostHog.kt
@@ -1,0 +1,14 @@
+package com.watermelon.context.utils
+import com.posthog.java.PostHog
+object PostHog {
+
+    // still need to figure this out
+//    private val POSTHOG_API_KEY = System.getProperties().get("POSTHOG_API_KEY") as String;
+//    private val POSTHOG_HOST = System.getProperties().get("POSTHOG_HOST") as String;
+
+
+    val posthog = PostHog.Builder(POSTHOG_API_KEY)
+        .host(POSTHOG_HOST)
+        .build()
+
+}


### PR DESCRIPTION
## Description
This PR inserts PostHog tracking to the plugin itself. Unlike what we're already tracking, we are able to track local usage (pre-authentication usage) as we do on VS Code. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
Gradle doesn't allow us to retrieve environment variables from gradle.properties on any file as the gradle configuration file (`build.gradle.kts`) does or as we do on NextJS by retrieving variables from a `.env` file. Whenever we build and publish we have to insert the Posthog API key manually. Running without the proper API key inserted doesn't produce any breaking change and the plugin runs normally. 

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
