### PR TITLE
Chore/remove supporters section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Alternatively, comment on our issues if you plan to solve one.
 ## Analytics
 Watermelon [doesn't store your code](https://www.watermelontools.com/post/building-a-code-archeology-toolbox-without-storing-your-code). In our commitment to transparency, we made our API (search engine) source-available. 
 
+We use [PostHog Analytics](https://posthog.com/) to track how users interact with Watermelon's IntelliJ Plugin.
+
 ---
 
 #### About Watermelon

--- a/README.md
+++ b/README.md
@@ -65,12 +65,6 @@ Alternatively, comment on our issues if you plan to solve one.
 ## Analytics
 Watermelon [doesn't store your code](https://www.watermelontools.com/post/building-a-code-archeology-toolbox-without-storing-your-code). In our commitment to transparency, we made our API (search engine) source-available. 
 
-## Supporters
-
-[![Stargazers repo roster for @watermelontools/watermelon-intellij](https://reporoster.com/stars/watermelontools/watermelon-intellij)](https://github.com/watermelontools/watermelon-intellij/stargazers)
-
-[![Forkers repo roster for @watermelontools/watermelon-intellij](https://reporoster.com/forks/watermelontools/watermelon-intellij)](https://github.com/watermelontools/watermelon-intellij/network/members)
-
 ---
 
 #### About Watermelon


### PR DESCRIPTION
## Description
We update the analytics section to clarify that we use PostHog, and we remove the supporters section because reporoster is broken. 

## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [x] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  
## Notes
<!--  This is a great place to add images or possible improvements -->
<!--  Remember you can use "Closes #106" to close Issue 106 (or any number) -->

## Acceptance
<!--  We need to make sure everything stays up to standard. -->
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
